### PR TITLE
Adding-SAITO-ERC20-Token (rates-API).

### DIFF
--- a/src/services/coinAggregatorIDs.js
+++ b/src/services/coinAggregatorIDs.js
@@ -23,7 +23,7 @@ const coinAggregatorIDs = {
     '0XBTC', 'AERGO', 'UBT', 'ILC', 'HEX', 'COMP', 'VIDT', 'DRGN', 'WBTC', 'OM', 'UNI',
     'JST', 'BDX', 'FIRO', 'CAKE', 'MATIC', 'ZCL', 'VBK', 'STETH', 'AMP', 'TEL', 'ONE',
     'AVAX', 'ATOM', 'AXS', 'XTZ', 'BTCB', 'SHIB', 'UST', 'YFI', 'SNX', 'NEAR', 'C98',
-    'ANKR', 'SXP', 'WRX', 'QUICK',
+    'ANKR', 'SXP', 'WRX', 'QUICK', 'SAITO',
   ],
   // Just add the coingecko ID in the end of this list
   coingecko: [


### PR DESCRIPTION
Adding SAITO ERC20 Token to coinAggregatorIDs.js file in rates-API repo as per integration scheme at Zelcore/docs/integratingERC20.md.